### PR TITLE
remove services "bot" and "scrapper" from docker compose file

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -82,27 +82,6 @@ services:
     volumes:
       - grafana_storage:/var/lib/grafana
 
-  bot:
-    image: bot-service-image
-    environment:
-      - TELEGRAM_TOKEN=${TELEGRAM_TOKEN}
-    depends_on:
-      - kafka1
-    ports:
-      - "8090:8090"
-      - "8091:8091"
-    network_mode: "host"
-
-  scrapper:
-    image: scrapper-service-image
-    depends_on:
-      - kafka1
-      - liquibase-migrations
-    ports:
-      - "8080:8080"
-      - "8081:8081"
-    network_mode: "host"
-
 volumes:
   postgresql: { }
   kafka-data: { }


### PR DESCRIPTION
Removing services that use potentially outdated docker images, which can be inconvenient for local manual testing.